### PR TITLE
4.7/cra visual comps

### DIFF
--- a/examples/cra/src/components/Button.tsx
+++ b/examples/cra/src/components/Button.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components'
+
+interface ButtonProps {
+    secondary?: boolean
+}
+
+export default styled.button<ButtonProps>`
+    display: inline-block;
+
+    border-radius: 25px;
+    border: none;
+
+    padding: 0.5rem 0;
+    margin: 0.5rem 1rem;
+    width: 14rem;
+
+    background: palevioletred;
+    color: white;
+
+    font-weight: 600;
+
+    cursor: pointer;
+
+    transition: all 0.25s ease-in-out;
+
+    &:hover {
+        box-shadow: 0px 0px 19px 0px #db709359;
+        background-color: #e8477c;
+    }
+
+    ${props =>
+        props.secondary &&
+        `
+            background: lightseagreen;
+            color: white;
+        `}
+    ${props =>
+        props.disabled &&
+        `
+            background-color: gray;
+            pointer-events: none;
+        `}
+`

--- a/examples/cra/src/components/ConnectButton.tsx
+++ b/examples/cra/src/components/ConnectButton.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import {
+    WalletConnectInits,
+} from '@gnosis.pm/dapp-ui'
+import WalletConnectProvider from "@walletconnect/web3-provider";
+
+import {useProvider, useWeb3} from '../hooks'
+
+
+import Button from './Button'
+import DisplayWeb3 from './DisplayWeb3'
+import DisplayProvider from './DisplayProvider'
+
+const wcOptions: WalletConnectInits = {
+    package: WalletConnectProvider,
+    options: {
+        infuraId: '8b4d9b4306294d2e92e0775ff1075066'
+    }
+
+}
+
+const ConnectWallet: React.FC = () => {
+
+    const {connectToProvider, disconnectFromProvider, provider, error} = useProvider(wcOptions)
+
+    const web3 = useWeb3(provider)
+
+    console.log('web3', !!web3);
+
+    (window as any).provider = provider;
+    (window as any).web3 = web3;
+
+    return (
+        <>
+            <Button onClick={connectToProvider}>
+                Open web3connect Modal
+            </Button>
+            {provider && <Button onClick={disconnectFromProvider} secondary>
+                Disconnect
+            </Button>}
+            {provider && <DisplayProvider title="Provider data" provider={provider} />}
+            <hr/>
+            {web3 && provider && <DisplayWeb3 title="Web3 data" web3={web3} provider={provider} />}
+            {error && <pre>Error: {error.message}</pre>}
+        </>
+    )
+}
+
+export default ConnectWallet

--- a/examples/cra/src/components/DisplayProvider.tsx
+++ b/examples/cra/src/components/DisplayProvider.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react'
+import {
+    Provider,
+    getProviderState,
+    createSubscriptions,
+    Subscriptions
+} from '@gnosis.pm/dapp-ui'
+import { useCurrentAccount, useNetwork, useIfMounted } from '../hooks'
+
+interface DisplayProviderProps {
+    provider: Provider
+    title?: string
+}
+
+const logSubscriptions = (subs: Subscriptions) => Object.entries<(cb: Function) =>
+    () => void>(subs as { [s: string]: any }).map(([key, sub]) => {
+        const unsub = sub((...args: any) => {
+            console.log(`${key} subscription:`, ...args)
+        })
+
+        return () => {
+            console.log(`unsubbing from ${key}`)
+            unsub()
+        }
+    });
+
+const useAllAvailableSubscriptions = (provider: Provider) => {
+    
+    useEffect(() => {
+        if (!provider) return
+        const subscriptions = createSubscriptions(provider)
+
+        const unsubs = logSubscriptions(subscriptions)
+
+        return () => unsubs.forEach(unsub => unsub())
+    }, [provider])
+}
+
+interface ClientVersion {
+    id?: number
+    jsonrpc?: string
+    result: string
+}
+
+export const DisplayProvider: React.FC<DisplayProviderProps> = ({ provider, title }) => {
+    const account = useCurrentAccount(provider)
+    const network = useNetwork(provider)
+
+    const providerState = getProviderState(provider)
+
+    useAllAvailableSubscriptions(provider)
+
+    const [clientVersion, setClientVersion] = useState<ClientVersion>()
+
+    const ifMounted = useIfMounted()
+
+    useEffect(() => {
+        provider.send({
+            method: 'web3_clientVersion',
+        }, (e, clientVersion) => ifMounted(() => setClientVersion(clientVersion)))
+    })
+
+    return (
+        <div>
+            {title && <h5>{title}</h5>}
+            <div>Account: {account}</div>
+            <div>Network: {network}</div>
+            <pre>
+                Client Version:
+                {JSON.stringify(clientVersion, null, 2)}
+            </pre>
+            <pre>
+                Provider State:
+                {JSON.stringify(providerState, null, 2)}
+            </pre>
+        </div>
+    )
+}
+
+export default DisplayProvider

--- a/examples/cra/src/components/DisplayWeb3.tsx
+++ b/examples/cra/src/components/DisplayWeb3.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import Web3 from 'web3'
+
+import {
+    Provider,
+} from '@gnosis.pm/dapp-ui'
+import { useAccountBalance, useCurrentAccount, useNetwork, useCurrentBlock, useIfMounted } from '../hooks'
+
+interface DisplayWeb3Props {
+    web3: Web3
+    provider: Provider
+    title?: string
+}
+
+export const DisplayWeb3: React.FC<DisplayWeb3Props> = ({ web3, provider, title }) => {
+    const [networkName, setNetworkName] = useState<number>()
+
+    const network = useNetwork(provider)
+
+    const ifMounted = useIfMounted()
+
+    useEffect(() => {
+        if (!web3) return
+        const setter = async (): Promise<void> => {
+            const networkName = await web3.eth.net.getId()
+
+            ifMounted(() => {
+                ReactDOM.unstable_batchedUpdates(() => {
+                    setNetworkName(networkName)
+                })
+            })
+
+        }
+
+        setter()
+    }, [web3, network, ifMounted])
+
+    const account = useCurrentAccount(provider)
+
+    const balance = useAccountBalance({account, web3})
+
+    const block = useCurrentBlock({provider, web3})
+
+    return (
+        <div>
+            {title && <h5>{title}</h5>}
+            <div>Account: {account}</div>
+            <div>Balance: {+balance / 1e18} ETH</div>
+            <div>Network from Web3: {networkName && networkName}</div>
+            <pre>
+                Latest Block:
+                {JSON.stringify(block, null, 2)}
+            </pre>
+        </div>
+    )
+}
+
+export default DisplayWeb3

--- a/examples/cra/src/index.tsx
+++ b/examples/cra/src/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import ConnectButton from './components/ConnectButton'
+
+const App: React.FC = () => {
+    return (
+        <div>
+            <ConnectButton />
+        </div>
+    )
+}
+
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
   },
   "homepage": "https://github.com/gnosis/dapp-ui#readme",
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server --mode development --hot",
-    "start:example-ts": "cd ./examples/ts-frontend && npm start && cd ../../",
+    "start": "npm run install:examples && npm run start:example-ts",
+    "start:example-ts": "npm --prefix ./examples/cra/ start",
+    "install:examples": "npm run build && npm --prefix ./examples/cra/ install",
     "build": "rimraf ./lib ./lib-esm && npm run build:commonjs && npm run build:esm",
     "build:commonjs": "tsc",
     "build:esm": "tsc -m es6 -t esnext --outDir lib-esm",


### PR DESCRIPTION
Adds component to actually use the hooks from #18 
`npm start` to run
Components display account, balance, network, block and clientVersion (something returned for `'web3_clientVersion'` rpc method)  and updated on change to account / network /block